### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,4 +1,4 @@
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 
 use IoC::Container;
 use IoC::ConstructorInjection;

--- a/t/02-sugar.t
+++ b/t/02-sugar.t
@@ -1,4 +1,4 @@
-BEGIN { @*INC.push('lib') };
+use lib 'lib';
 
 use IoC;
 use Test;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
