### PR TITLE
Add missing provides section in META

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,6 +3,14 @@
     "version"     : "*",
     "description" : "Wire your application components together using inversion of control",
     "depends"     : [ ],
+    "provides"    : {
+       "Ioc"  : "lib/IoC.pm6",
+       "IoC::BlockInjection" : "lib/IoC/BlockInjection.pm6",
+       "IoC::ConstructorInjection" : "lib/IoC/ConstructorInjection.pm6",
+       "IoC::Container" : "lib/IoC/Container.pm6",
+       "IoC::Literal" : "lib/IoC/Literal.pm6",
+       "IoC::Service" : "lib/IoC/Service.pm6"
+    },
     "source-type"   : "git",
     "source-url"    : "git://github.com/jasonmay/perl6-ioc.git"
 }


### PR DESCRIPTION
We were just reviewing the log of the modules list builder

```
[Wed Oct 26 18:26:59 2016] [info] Processing dist 91 of 739
[Wed Oct 26 18:26:59 2016] [info] Using ModulesPerl6::DbBuilder::Dist::Source::GitHub to load https://raw.githubusercontent.com/jasonmay/perl6-ioc/master/META.info
[Wed Oct 26 18:26:59 2016] [info] Fetching distro info and commits
[Wed Oct 26 18:26:59 2016] [info] Downloading META file from https://raw.githubusercontent.com/jasonmay/perl6-ioc/master/META.info
[Wed Oct 26 18:26:59 2016] [info] Parsing META file
[Wed Oct 26 18:26:59 2016] [warn] Required `perl` field is missing
[Wed Oct 26 18:26:59 2016] [warn] Required `provides` field is missing
[Wed Oct 26 18:27:00 2016] [info] dist source URL is same as META repo URL (https://github.com/jasonmay/perl6-ioc)

```

There is a PR for the missing 'perl' before this one :)
